### PR TITLE
#138 Fix saving of user's location and description

### DIFF
--- a/Src/Common/Domain/constants/Constants.cs
+++ b/Src/Common/Domain/constants/Constants.cs
@@ -25,7 +25,9 @@
         public const int USER_PASSWORD_MIN_LENGTH = 1;
 
         public const int VOLUNTEER_PROFILE_DESCRIPTION_MAX_LENGTH = 500;
-        public const int VOLUNTEER_PROFILE_DESCRIPTION_MIN_LENGTH = 1;
+        public const int VOLUNTEER_PROFILE_DESCRIPTION_MIN_LENGTH = 0;
+        public const int VOLUNTEER_PROFILE_LOCATION_MAX_LENGTH = 200;
+        public const int VOLUNTEER_PROFILE_LOCATION_MIN_LENGTH = 0;
         public const int VOLUNTEER_PROFILE_NAME_MAX_LENGTH = 50;
         public const int VOLUNTEER_PROFILE_NAME_MIN_LENGTH = 1;
 

--- a/Src/Common/Presentation/Model/UserModel.cs
+++ b/Src/Common/Presentation/Model/UserModel.cs
@@ -20,9 +20,15 @@ namespace Ttu.Presentation
 
         #region Properties
 
+        [Required]
+        [StringLength(Constants.USER_FIRST_NAME_MAX_LENGTH, ErrorMessage = "The {0} must be at least {2} characters long.", MinimumLength = Constants.USER_FIRST_NAME_MIN_LENGTH)]
+        [DataType(DataType.Text)]
         [Display(Name = "First Name")]
         public string FirstName { get; set; }
 
+        [Required]
+        [StringLength(Constants.USER_LAST_NAME_MAX_LENGTH, ErrorMessage = "The {0} must be at least {2} characters long.", MinimumLength = Constants.USER_LAST_NAME_MIN_LENGTH)]
+        [DataType(DataType.Text)]
         [Display(Name = "Last Name")]
         public string LastName { get; set; }
 
@@ -31,9 +37,13 @@ namespace Ttu.Presentation
         [Display(Name = "User ID")]
         public string UserId { get; set; }
 
+        [StringLength(Constants.VOLUNTEER_PROFILE_LOCATION_MAX_LENGTH, ErrorMessage = "The {0} must be at least {2} characters long.", MinimumLength = Constants.VOLUNTEER_PROFILE_LOCATION_MIN_LENGTH)]
+        [DataType(DataType.Text)]
         [Display(Name = "Location")]
         public string Location { get; set; }
 
+        [StringLength(Constants.VOLUNTEER_PROFILE_DESCRIPTION_MAX_LENGTH, ErrorMessage = "The {0} must be at least {2} characters long.", MinimumLength = Constants.VOLUNTEER_PROFILE_DESCRIPTION_MIN_LENGTH)]
+        [DataType(DataType.Text)]
         [Display(Name = "Description")]
         public string Description { get; set; }
 

--- a/Src/Service/Service/persistence/hbm/user.hbm.xml
+++ b/Src/Service/Service/persistence/hbm/user.hbm.xml
@@ -8,6 +8,8 @@
         <property name="EmailAddress" length="100" />
         <property name="FirstName" length="50" />
         <property name="LastName" length="50" />
+        <property name="Description" length="500" />
+        <property name="Location" length="200" />
         <property name="PasswordEncrypted" length="200" />
         <property name="UserId" length="100" />
 


### PR DESCRIPTION
Location and description weren't in the hbm file. I also added validation for all the user data (leaving location and description optional).